### PR TITLE
コマンド名のlxcをincusに修正

### DIFF
--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -65,7 +65,7 @@ Incus はこの方法を強制しませんが、プロファイルとインス�
 
 インスタンスに直接`cloud-init`を設定する場合、`cloud-init`はインスタンスの最初の起動時にのみ実行されることに注意してください。
 つまり、インスタンスを起動する前に`cloud-init`を設定する必要があります。
-これを行うには、`lxc launch`の代わりに`lxc init`でインスタンスを作成し、設定が完了した後に起動します。
+これを行うには、[`incus launch`](incus_launch.md)の代わりに[`incus init`](incus_create.md)でインスタンスを作成し、設定が完了した後に起動します。
 
 ### `cloud-init`設定のYAMLフォーマット
 

--- a/doc/explanation/clustering.md
+++ b/doc/explanation/clustering.md
@@ -195,7 +195,7 @@ def instance_placement(request, candidate_members):
 
     cat instance_placement.star | incus config set instances.placement.scriptlet=-
 
-Incus に現在適用されているスクリプトレットを見るには`lxc config get instances.placement.scriptlet`コマンドを使用してください。
+Incus に現在適用されているスクリプトレットを見るには`incus config get instances.placement.scriptlet`コマンドを使用してください。
 
 スクリプトレットでは（Starlark で提供される関数に加えて）以下の関数が利用できます:
 

--- a/doc/howto/incus_alias.md
+++ b/doc/howto/incus_alias.md
@@ -8,7 +8,7 @@ Incus コマンドラインクライアントでは良く使うコマンドの�
 
 たとえば、インスタンスを削除する際に必ず確認を求めるようにするには`incus delete`に常に`incus delete -i`を実行するようにエイリアスを作成します:
 
-    lxc alias add delete "delete -i"
+    incus alias add delete "delete -i"
 
 登録されたすべてののエイリアスを表示するには[`incus alias list`](incus_alias_list.md)を実行します。
 すべての利用可能なサブコマンドを表示するには[`incus alias --help`](incus_alias.md)を実行してください。

--- a/doc/howto/instances_create.md
+++ b/doc/howto/instances_create.md
@@ -38,7 +38,7 @@
 
 たとえば、`config.yaml` の設定でコンテナを起動するには、以下のコマンドを入力します:
 
-    lxc launch images:ubuntu/22.04 ubuntu-config < config.yaml
+    incus launch images:ubuntu/22.04 ubuntu-config < config.yaml
 
     incus launch images:ubuntu/22.04 ubuntu-config < config.yaml
 

--- a/doc/howto/network_zones.md
+++ b/doc/howto/network_zones.md
@@ -47,7 +47,7 @@ Incus はすべてのインスタンス、ネットワークゲートウェイ�
 
 特定のゾーンに対して`dig`リクエストが許可されるようにするためには、そのゾーンの`peers.NAME.address`設定オプションを設定する必要があります。`NAME`はランダムなもので構いません。値は、`dig`が呼び出される IP アドレスと一致しなければなりません。同じランダムな`NAME`の`peers.NAME.key`は未設定のままにしておく必要があります。
 
-例: `lxc network zone set incus.example.net peers.whatever.address=192.0.2.1`
+例: `incus network zone set incus.example.net peers.whatever.address=192.0.2.1`
 
 ```{note}
 `dig`が呼び出し元の同じマシンのアドレスであるだけでは十分ではありません。それは、`incus`内のDNSサーバーが正確なリモートアドレスと考えるものと文字列で一致する必要があります。`dig`は`0.0.0.0`にバインドするため、必要なアドレスはおそらく、あなたが`core.dns_address`に提供したものと同じです。

--- a/doc/instance-exec.md
+++ b/doc/instance-exec.md
@@ -52,7 +52,7 @@ Incus はインスタンス内のデータを読まない、あるいはその�
 インスタンスオプションとして環境変数を渡す
 : インスタンス内で`ENVVAR`環境変数を`VALUE`に設定するには、`environment.ENVVAR`インスタンスオプション を設定します（{config:option}`instance-miscellaneous:environment.*`参照）:
 
-      lxc config set <instance_name> environment.ENVVAR=VALUE
+      incus config set <instance_name> environment.ENVVAR=VALUE
 
 exec コマンドに環境変数を渡す
 : exec コマンドに環境変数を渡すには、`--env`フラグを使います。
@@ -95,12 +95,12 @@ exec コマンドに環境変数を渡す
 インスタンス内で直接コマンドを実行したい場合、インスタンス内でシェルコマンドを実行します。
 たとえば、以下のコマンド（インスタンス内に`/bin/bash`コマンドが存在する想定）を入力します。
 
-    lxc exec <instance_name> -- /bin/bash
+    incus exec <instance_name> -- /bin/bash
 
 デフォルトでは`root`ユーザーでログインします。
 別のユーザーでログインしたい場合は、以下のコマンドを入力します:
 
-    lxc exec <instance_name> -- su --login <user_name>
+    incus exec <instance_name> -- su --login <user_name>
 
 ```{note}
 インスタンス内で稼働しているオペレーティングシステムによっては、先にユーザを作成する必要があるかもしれません。

--- a/doc/tutorial/first_steps.md
+++ b/doc/tutorial/first_steps.md
@@ -43,7 +43,7 @@ Incus はイメージベースです。そしてさまざまなイメージサ�
 
 このイメージサーバーで利用可能なすべてのイメージを一覧表示するには以下のようにします。
 
-    lxc image list images:
+    incus image list images:
 
 Incus が使用するイメージについてのより詳細情報は{ref}`images`を参照してください。
 


### PR DESCRIPTION
さらにGoのソース内のコマンド例の文字列にもlxcが1箇所残っているのに気づいたのでupstreamにプルリクエストを送っています。[doc: replace lxc with incus in cmdStorageVolumeSnapshotShow example by hnakamur · Pull Request #235 · lxc/incus](https://github.com/lxc/incus/pull/235)
これがマージされたら、その変更も合わせて取り込もうと思います。

一旦 https://github.com/lxc-jp/incus-ja/commit/4302b10c4ceabc07926dcc057349e0a2a3fc43e4 を
https://incus-ja.readthedocs.io/ja/staging/ でビルドしました。